### PR TITLE
Support for uncompressed messages

### DIFF
--- a/lib/gelfd.rb
+++ b/lib/gelfd.rb
@@ -4,6 +4,7 @@ module Gelfd
   CHUNKED_MAGIC = [0x1e,0x0f].pack('C*').freeze
   ZLIB_MAGIC = [0x78,0x9c].pack('C*').freeze
   GZIP_MAGIC = [0x1f,0x8b].pack('C*').freeze
+  UNCOMPRESSED_MAGIC = [0x1f,0x3c].pack('C*').freeze
   HEADER_LENGTH = 12
   DATA_LENGTH = 8192 - HEADER_LENGTH
   MAX_CHUNKS = 128

--- a/lib/gelfd/parser.rb
+++ b/lib/gelfd/parser.rb
@@ -10,6 +10,8 @@ module Gelfd
         ChunkedParser.parse(data)
       when GZIP_MAGIC
         GzipParser.parse(data)
+      when UNCOMPRESSED_MAGIC
+        data[2..-1]
       else
         raise UnknownHeaderError, "Could not find parser for header: #{header.unpack('C*').to_s}"
       end

--- a/test/fixtures/unchunked.uc
+++ b/test/fixtures/unchunked.uc
@@ -1,0 +1,1 @@
+<{"this":"is","my":"boomstick"}

--- a/test/tc_uncompressed.rb
+++ b/test/tc_uncompressed.rb
@@ -1,0 +1,14 @@
+$:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "lib")))
+require 'gelfd'
+require 'json'
+require 'test/unit'
+
+class TestUncompressedGelf < Test::Unit::TestCase
+  FIXTURE_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
+  
+  def test_uncompressed_message
+    data = File.open("#{FIXTURE_PATH}/unchunked.uc", "rb") {|f| f.read}
+    t = Gelfd::Parser.parse(data)
+    assert_equal('{"this":"is","my":"boomstick"}', t)
+  end
+end

--- a/test/ts_all.rb
+++ b/test/ts_all.rb
@@ -1,4 +1,5 @@
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "test")))
 require 'test/unit'
 require 'tc_unchunked'
+require 'tc_uncompressed'
 require 'tc_chunked'


### PR DESCRIPTION
The library currently expects all the messages to compressed using Gzip or Zlib. If the entire message is shorter than the chunk size the message can be sent without compression. The graylog2 server also supports this[1]. Uncompressed message support will help us to save some cycles in the both server and client when many messages are shorter than the chunk size. I have added a patch to support uncompressed messages.
