### PR TITLE
remove uncompressed data magic header

### DIFF
--- a/lib/gelfd/parser.rb
+++ b/lib/gelfd/parser.rb
@@ -10,10 +10,9 @@ module Gelfd
         ChunkedParser.parse(data)
       when GZIP_MAGIC
         GzipParser.parse(data)
-      when UNCOMPRESSED_MAGIC
-        data[2..-1]
       else
-        raise UnknownHeaderError, "Could not find parser for header: #{header.unpack('C*').to_s}"
+        # by default assume the payload to be "raw, uncompressed" GELF, parsing will fail if it's malformed.
+        data
       end
     end
 

--- a/test/fixtures/unchunked.uc
+++ b/test/fixtures/unchunked.uc
@@ -1,1 +1,1 @@
-<{"this":"is","my":"boomstick"}
+{"this":"is","my":"boomstick"}

--- a/test/tc_uncompressed.rb
+++ b/test/tc_uncompressed.rb
@@ -5,7 +5,7 @@ require 'test/unit'
 
 class TestUncompressedGelf < Test::Unit::TestCase
   FIXTURE_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
-  
+
   def test_uncompressed_message
     data = File.open("#{FIXTURE_PATH}/unchunked.uc", "rb") {|f| f.read}
     t = Gelfd::Parser.parse(data)


### PR DESCRIPTION
default to returning uncompressed data without checking for magic header for
compliant with graylog2 server. Relevant piece for graylog2 server is at
https://github.com/Graylog2/graylog2-server/blob/edd1a66a2f9924e39b217df4c94327a86b8fecab/graylog2-server/src/main/java/org/graylog2/inputs/codecs/gelf/GELFMessage.java#L147
