### PR TITLE
Use ruby mechanisms for detecting files instead of git

### DIFF
--- a/gelfd.gemspec
+++ b/gelfd.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "gelfd"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir["lib/**/*","test/**/*","bin/*", "*.gemspec", "*.md",'Gemfile','LICENSE','Rakefile']
+  s.test_files    = Dir["test/**/*"]
+  s.executables   = ["gelfd"]
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:


### PR DESCRIPTION
git isn't guaranteed to be installed on all systems, especially when installing gelfd inside of Docker containers.